### PR TITLE
fix: Use actual URL for baseUrl

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from "~~/components/ThemeProvider";
 import "~~/styles/globals.css";
 
 const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+  ? "https://zk-voting.com"
   : `http://localhost:${process.env.PORT || 3000}`;
 const imageUrl = `${baseUrl}/thumbnail.jpg`;
 


### PR DESCRIPTION
## Description

It seems like the `VERCEL_PROJECT_PRODUCTION_URL` is currently private, so we are not able to see the correct metadata tags. I'm changing it to be `https://zk-voting.com` so that it matches the actual production url.